### PR TITLE
exception when running CMS on MacOS

### DIFF
--- a/src/Exceptions/CryptoException.php
+++ b/src/Exceptions/CryptoException.php
@@ -48,4 +48,14 @@ class CryptoException extends \RuntimeException
 
         return new self(sprintf("error while reading keyfile %s: file is not readable by user (try chmod 644)", $path));
     }
+
+    public static function opensslVersion(): CryptoException
+    {
+        return new self('MacOS ships with an incompatible openssl (libreSSL) that does not support CMS encryption');
+    }
+
+    public static function opensslNotFound(): CryptoException
+    {
+        return new self('Cannot find openssl binary');
+    }
 }


### PR DESCRIPTION
MacOS uses libreSSL which does not support CMS. We throw an exception to the user instead of trying (and failing) the signing.