### PR TITLE
Added additional check on CMS Verification

### DIFF
--- a/src/Service/Signature/ProcessSpawnService.php
+++ b/src/Service/Signature/ProcessSpawnService.php
@@ -138,8 +138,10 @@ class ProcessSpawnService implements SignatureCryptoInterface
             // Successful and failure are expected.
             if (
                 !empty($errOutput)
-                && !str_contains($errOutput, "Verification successful")
-                && !str_contains($errOutput, "Verification failure")
+                && !str_starts_with($errOutput, "Verification successful")
+                && !str_starts_with($errOutput, "Verification failure")
+                && !str_starts_with($errOutput, "CMS Verification successful")
+                && !str_starts_with($errOutput, "CMS Verification failure")
             ) {
                 throw CryptoException::verify($errOutput);
             }


### PR DESCRIPTION
We throw a crypto exception when the output does not start with `Verification successful` of `Verification failure`.
For the latest opensssl version this message is changed to `CMS Verification successful` and `CMS Verification failure`.

Based on the process exitcode the validation is successful or not, so we do not update the validation logic. This change only updates when we throw an crypto exception if there is an output we did not expect.

Instead of #22 using str_contains check we want to explicitly check if the output start with exprected message.