### PR TITLE
Fix certfile when signing

### DIFF
--- a/src/Service/Signature/ProcessSpawnService.php
+++ b/src/Service/Signature/ProcessSpawnService.php
@@ -69,7 +69,7 @@ class ProcessSpawnService implements SignatureCryptoInterface
             $args = array_merge($args, ['-passin', $this->privKeyPass]);
         }
         if (!empty($this->certChainPath)) {
-            $args = array_merge($args, ['-CAfile', $this->certChainPath]);
+            $args = array_merge($args, ['-certfile', $this->certChainPath]);
         }
 
         $process = new Process($args);


### PR DESCRIPTION
-certfile is the property to provide other certificates that should be included in the signature

https://www.openssl.org/docs/man3.1/man1/openssl-cms.html
https://www.openssl.org/docs/man1.1.1/man1/openssl-cms.html